### PR TITLE
Add configurable executable name support

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,9 @@ The application creates a config file at `~/arma3-mod-launcher-console-config.js
 }
 ````
 
-If the application cannot resolve the correct paths, you can edit them here. The `executable_name` field allows you to specify a different Arma 3 executable name (without the `.app` extension) if needed.
+If the application cannot resolve the correct paths, you can edit them here. The `executable_name` field allows you to specify a different Arma 3 executable name:
+- On macOS: without the `.app` extension (e.g., "arma3")
+- On Linux: the actual executable name (e.g., "arma3_x64")
 
 ### Custom Mods
 
@@ -84,13 +86,13 @@ Simply move your mods into the custom mods folder. The folder will be alongside 
 1. **Check Config File**: Verify `~/arma3-mod-manager-console-config.json` has the correct Steam path.
 2. **Ensure Workshop Mods**: Confirm Arma 3 workshop mods are installed via Steam.
 3. **Locate Steam Path**:
-   - For MacOS check for `~/Library/Application Support/Steam`
-   - For Linux check for  `~/.local/share/Steam`
+   - For macOS: check for `~/Library/Application Support/Steam`
+   - For Linux: check for `~/.local/share/Steam`
 
 **Adjust and test** the paths, then rerun the application.
 
-### Mods Compatability
-Not 100% of Arma 3 mods are compatible with Mac or Linux.
+### Mods Compatibility
+Not 100% of Arma 3 mods are compatible with macOS or Linux.
 
 Mods that require .DLL files will not work so no ACE, TFR/ACRE or blastcore.
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ The application creates a config file at `~/arma3-mod-launcher-console-config.js
   "game_path": "/Users/user/Library/Application Support/Steam/steamapps/common/Arma 3",
   "workshop_path": "/Users/user/Library/Application Support/Steam/steamapps/workshop/content/107410",
   "custom_mods_path": "/Users/user/arma3-mod-manager-console-custom-mods",
+  "executable_name": "arma3",
   "enabled_mods": [
     
   ],
@@ -65,7 +66,7 @@ The application creates a config file at `~/arma3-mod-launcher-console-config.js
 }
 ````
 
-If the application cannot resolve the correct paths, you can edit them here.
+If the application cannot resolve the correct paths, you can edit them here. The `executable_name` field allows you to specify a different Arma 3 executable name (without the `.app` extension) if needed.
 
 ### Custom Mods
 

--- a/src/mod_manager/config.rs
+++ b/src/mod_manager/config.rs
@@ -14,6 +14,8 @@ pub struct Config {
     game_path: String,
     workshop_path: String,
     custom_mods_path: Option<String>, // Optional
+    #[serde(default = "default_executable_name")]
+    executable_name: String,
     #[serde(deserialize_with = "deserialize_mods")]
     enabled_mods: Vec<String>,
     default_args: String,
@@ -38,6 +40,10 @@ where
     Ok(mods)
 }
 
+fn default_executable_name() -> String {
+    "arma3".to_string()
+}
+
 impl Config {
     fn get_save_path() -> AppResult<PathBuf> {
         let home_path = utils::get_home_path()?;
@@ -54,6 +60,7 @@ impl Config {
             game_path,
             workshop_path,
             custom_mods_path,
+            executable_name: default_executable_name(),
             enabled_mods: Vec::new(),
             default_args: "-noSplash -skipIntro -world=empty".to_string(),
         };
@@ -91,6 +98,14 @@ impl Config {
 
     pub fn get_custom_mods_path(&self) -> Option<&Path> {
         self.custom_mods_path.as_deref().map(Path::new)
+    }
+
+    pub fn get_executable_name(&self) -> &str {
+        &self.executable_name
+    }
+
+    pub fn set_executable_name(&mut self, name: String) {
+        self.executable_name = name;
     }
 
     pub fn get_default_args(&self) -> &str {

--- a/src/mod_manager/terminal.rs
+++ b/src/mod_manager/terminal.rs
@@ -306,22 +306,20 @@ impl<'a> Terminal<'a> {
 
         let executable_name = self.mod_manager.config.get_executable_name();
         let game_app_path = game_path.join(format!("{}.app", executable_name));
-        let game_app_path_str = game_app_path.to_string_lossy().to_string();
+        let executable_path = game_app_path.join("Contents/MacOS").join(executable_name);
+        let executable_path_str = executable_path.to_string_lossy().to_string();
 
-        if !game_app_path.exists() {
-            return Err(AppError::InvalidPath(game_app_path_str.to_owned()));
+        if !executable_path.exists() {
+            return Err(AppError::InvalidPath(executable_path_str.to_owned()));
         }
 
-        let mut command = Command::new("open");
-
-        command.args(["-a", &game_app_path_str]);
+        let mut command = Command::new(&executable_path_str);
+        command.current_dir(game_path);
 
         // Remove existing symlinks from the game directory
         super::file_handler::remove_dir_symlinks(game_path)?;
 
         if !enabled_mods.is_empty() {
-            command.arg("--args");
-
             // Exclude CDLCS when creating sym links since they already are in the game folder
             // only for workshop + custom mods
             let mod_paths: Vec<_> = enabled_mods


### PR DESCRIPTION
Add configurable executable name support

- Add executable_name field to config with default value "arma3"
- Add interactive screen to set executable name via 'E' key
- Update game launch logic to use configurable executable name
- Update README with documentation for new executable_name config option

This allows users to specify a different Arma 3 executable name
(without .app extension) if needed for their setup.